### PR TITLE
Update babel preset

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015"]
+  "presets": ["env"]
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "autoprefixer": "^6.0.3",
     "babel-core": "^6.2.1",
     "babel-loader": "^6.2.0",
-    "babel-preset-es2015": "^6.1.18",
+    "babel-preset-env": "^1.6.1",
     "copy-webpack-plugin": "4.0.1",
     "css-loader": "0.26.1",
     "extract-text-webpack-plugin": "2.0.0-beta.5",


### PR DESCRIPTION
Removed deprecated `babel-preset-es2015` to use `babel-preset-env`.