### PR TITLE
Remove deprecated dedupe plugin usage

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -194,10 +194,6 @@ module.exports = function makeWebpackConfig() {
       // Only emit files when there are no errors
       new webpack.NoErrorsPlugin(),
 
-      // Reference: http://webpack.github.io/docs/list-of-plugins.html#dedupeplugin
-      // Dedupe modules in the output
-      new webpack.optimize.DedupePlugin(),
-
       // Reference: http://webpack.github.io/docs/list-of-plugins.html#uglifyjsplugin
       // Minify all javascript, switch loaders to minimizing mode
       new webpack.optimize.UglifyJsPlugin(),


### PR DESCRIPTION
See:
https://webpack.js.org/migrate/3/#dedupeplugin-has-been-removed

Thanks!